### PR TITLE
Bug in wp_cache_post_chage()

### DIFF
--- a/wp-cache-phase2.php
+++ b/wp-cache-phase2.php
@@ -1071,7 +1071,7 @@ function wp_cache_post_id_gc( $siteurl, $post_id, $all = 'all' ) {
 }
 
 function wp_cache_post_change( $post_id ) {
-	global $file_prefix, $cache_path, $blog_id, $super_cache_enabled, $blog_cache_dir, $blogcacheid, $wp_cache_refresh_single_only;
+	global $file_prefix, $cache_path, $blog_id, $super_cache_enabled, $blog_cache_dir, $blogcacheid, $wp_cache_refresh_single_only, $wp_cache_object_cache;
 	static $last_processed = -1;
 
 	if ( $post_id == $last_processed ) {


### PR DESCRIPTION
I ran into an interesting bug in this function where $wp_cache_object_cache is checked in an if statement, but isn't defined inside the function [line 1105].

I've added it to the [line 1074] as a global import. I'm not sure if this is the appropriate location since I'm not familiar with the plugin, but was getting errors without it there.

Thanks!
